### PR TITLE
Add more links

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,7 @@ A collection of resources for Propeller Community members.
   * [fastspin](https://github.com/totalspectrum/spin2cpp/releases) -
 P1 and P2 [Spin](https://github.com/totalspectrum/spin2cpp/blob/master/doc/spin.md),
 [BASIC](https://github.com/totalspectrum/spin2cpp/blob/master/doc/basic.md) and
-[C](https://github.com/totalspectrum/spin2cpp/blob/master/doc/c.md) compiler by Eric H. Smith
+[C](https://github.com/totalspectrum/spin2cpp/blob/master/doc/c.md) compiler by Eric R. Smith
     - [Spin2gui](https://github.com/totalspectrum/spin2gui/releases) - IDE for fastspin by Eric R. Smith.
     - See [Spin2gui source readme](https://github.com/totalspectrum/spin2gui/blob/master/README.md) for documentation
   * [p2gcc, p2asm & loadp2](https://github.com/davehein/p2gcc) - P2 C compiler/assembler/linker/loader by Dave Hein.

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,11 +15,20 @@ A collection of resources for Propeller Community members.
   * [P2 FPGA Emulation](http://forums.parallax.com/discussion/144199/propeller-ii-emulation-of-the-p2-on-fpga-boards-prop123-a7-a9-de0-nano-de2-115-etc#latest) discussion.
 
 ### Software
-  * [PNut](https://github.com/parallaxinc/propeller/releases/download/v32i/PNut_v32i.exe) - Parallax P2 IDE (windows, can be used with wine).
-  * [Spin2gui](https://github.com/totalspectrum/spin2gui/releases) - P2 (and P1) Spin, BASIC, and C IDE by Eric R. Smith.
-    - [See Spin2gui source readme](https://github.com/totalspectrum/spin2gui/blob/master/README.md) for documentation
-    - [fastspin](https://github.com/totalspectrum/spin2cpp/releases) - Spin, BASIC and C compiler (used by Spin2gui)
-  * [p2gcc and loadp2](https://github.com/davehein/p2gcc) - P2 C compiler/linker/loader by Dave Hein.
+  * [PNut](https://github.com/parallaxinc/propeller/releases/download/v32i/PNut_v32i.exe) - Parallax P2 IDE (windows, can be used with wine on Linux and MacOS).
+  * [boot rom P2 v32i](https://www.dropbox.com/sh/ssdb8di5g90ycng/AACi8dWtLuqV5vzUSjJc6SDQa?dl=0) - P2 boot ROM as available on P2-ES board
+  * [boot rom P2 v33j](http://forums.parallax.com/discussion/comment/1465155/#Comment_1465155) - P2 boot ROM for coming [P2 revision](https://forums.parallax.com/discussion/169282/list-of-changes-in-next-p2-silicon)
+  * [fastspin](https://github.com/totalspectrum/spin2cpp/releases) -
+P1 and P2 [Spin](https://github.com/totalspectrum/spin2cpp/blob/master/doc/spin.md),
+[BASIC](https://github.com/totalspectrum/spin2cpp/blob/master/doc/basic.md) and
+[C](https://github.com/totalspectrum/spin2cpp/blob/master/doc/c.md) compiler by Eric H. Smith
+    - [Spin2gui](https://github.com/totalspectrum/spin2gui/releases) - IDE for fastspin by Eric R. Smith.
+    - See [Spin2gui source readme](https://github.com/totalspectrum/spin2gui/blob/master/README.md) for documentation
+  * [p2gcc, p2asm & loadp2](https://github.com/davehein/p2gcc) - P2 C compiler/assembler/linker/loader by Dave Hein.
+  * [Catalina](https://forums.parallax.com/discussion/168399/catalina-and-the-p2) - P2 C Compiler/linker by RossH
+  * [MicroPython](https://forums.parallax.com/discussion/169862/micropython-for-p2) - P2 microPython implementation by Eric R. Smith
+  * [pyLoader](https://forums.parallax.com/discussion/168850/python-p2-loader) - P2 binary loader written in python by ozpropdev
+  * [flash loader](https://forums.parallax.com/discussion/169608/prop2-flash-loader) - Load program in flash by ozpropdev
 
 ### Hardware
   * [P2-ES Board](https://www.parallax.com/product/64000-es)


### PR DESCRIPTION
Re-arrange fastspin and spin2gui links and add links to spin/basic/c documentation
Add reference to p2asm (as part of p2gcc)
Add some new links:
 - boot ROMs for v32i and v33j 
 - microPython
 - Catalina
 - load program in flash
 - python P2 loader

Will soon(ish) propose new pages for 
 - other SW as I'm slowly working my way through all posts in the P2 forum (will follow the suggested structure for the example code section)
 - tips & tricks
