### PR TITLE
Fix invalid markdown syntax

### DIFF
--- a/libraries/readme.md
+++ b/libraries/readme.md
@@ -7,5 +7,5 @@ The ["p1" (Propeller 1)](https://github.com/parallaxinc/propeller/tree/master/li
 ## Contents and Structure
 As further Propeller 1 objects are created, or as the Propeller 2 is tested and further materials are developed, the "p1" and "p2" folder contents should evolve organically to stay organized- items categorized in subfolders.
 
-Contributors can [create](https://github.com/parallaxinc/propeller/wiki/Contributing) and/or [suggest](mailto\\:developer+github@parallax.com?subject=Propeller+Repository+Suggestion) new or renamed subfolders when the need arises.
+Contributors can [create](https://github.com/parallaxinc/propeller/wiki/Contributing) and/or [suggest](mailto:developer+github@parallax.com?subject=Propeller+Repository+Suggestion) new or renamed subfolders when the need arises.
   

--- a/resources/readme.md
+++ b/resources/readme.md
@@ -4,5 +4,5 @@ This folder contains Propeller 2 example code developed and shared by the Propel
 ## Contents and Structure
 As the Propeller 2 is tested and further materials are developed, this folder and it's contents should evolve organically to stay organized- items categorized in subfolders.
 
-Contributors can [create](https://github.com/parallaxinc/propeller/wiki/Contributing) and/or [suggest](mailto\\:developer+github@parallax.com?subject=Propeller+Repository+Suggestion) new or renamed subfolders when the need arises.
+Contributors can [create](https://github.com/parallaxinc/propeller/wiki/Contributing) and/or [suggest](mailto:developer+github@parallax.com?subject=Propeller+Repository+Suggestion) new or renamed subfolders when the need arises.
   


### PR DESCRIPTION
The escaping is unnecessary and prevents the link from rendering correctly on GitHub's site